### PR TITLE
Update python and packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM google/cloud-sdk
 RUN apt update && apt install -y jq
+RUN python3 -m pip config set global.break-system-packages true
 RUN pip3 --version && pip3 install requests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM google/cloud-sdk
 RUN apt update && apt install -y jq
 RUN python3 -m pip config set global.break-system-packages true
-RUN pip3 --version && pip3 install requests
+RUN pip3 --version && pip3 install requests slack_sdk


### PR DESCRIPTION
Needed to update to latest GCP base image which gives updated python. Also use break-system-packages set to true in order for promotion to use pip3.  Tested and is working well.